### PR TITLE
Add minimal SwiftUI iOS app

### DIFF
--- a/AppstoreApp.swift
+++ b/AppstoreApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppstoreApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, Appstore!")
+            .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Appstore
+
+This repository contains sample SwiftUI code for a minimal iOS app displaying "Hello, Appstore!".
+
+## Getting Started
+
+1. Create a new SwiftUI App project in Xcode.
+2. Replace the generated `App.swift` and `ContentView.swift` files with the versions in this repository.
+3. Build and run the app on an iOS simulator or device.


### PR DESCRIPTION
## Summary
- add basic SwiftUI App entry point and content view
- document steps for integrating the sample iOS app

## Testing
- `swiftc -typecheck AppstoreApp.swift ContentView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aaf75870908324938eb50138f4a41b